### PR TITLE
Fix menu file globbing and improve server logging setup

### DIFF
--- a/server/menu.sh
+++ b/server/menu.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Expand globs to nothing when there is no match to avoid bogus entries
+shopt -s nullglob
 
 DATA_DIR="./data"
 
@@ -28,7 +30,7 @@ main_menu() {
 view_host() {
     OPTIONS=()
     i=1
-    for FILE in "$DATA_DIR"/*; do
+    for FILE in "$DATA_DIR"/*.json; do
         HOSTNAME=$(basename "$FILE" .json)
         OPTIONS+=($i "$HOSTNAME")
         ((i++))
@@ -74,7 +76,7 @@ show_summary() {
 delete_host() {
     OPTIONS=()
     i=1
-    for FILE in "$DATA_DIR"/*; do
+    for FILE in "$DATA_DIR"/*.json; do
         HOSTNAME=$(basename "$FILE" .json)
         OPTIONS+=($i "$HOSTNAME")
         ((i++))

--- a/server/server.sh
+++ b/server/server.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
-exec 2> ./log/server_error.log
+
+LOG_DIR="./log"
+mkdir -p "$LOG_DIR"
+exec 2> "$LOG_DIR/server_error.log"
 
 PORT=9999
 DATA_DIR="./data"
@@ -13,7 +16,7 @@ log() {
 
 # Create the folder if inexistant
 log "[INFO] Check ou création du répertoire $DATA_DIR"
-mkdir $DATA_DIR
+mkdir -p "$DATA_DIR"
 
 # Initiate the server
 log "[INFO] Démarrage du serveur sur le port $PORT"


### PR DESCRIPTION
## Summary
- avoid bogus entries in menu when data directory empty by enabling `nullglob`
- only iterate over JSON files in menu loops
- create server log directory before redirection and use `mkdir -p`

## Testing
- `bash -n server/menu.sh`
- `bash -n server/server.sh`
- `bash -n installer_server.sh`
- `bash -n installer_agent.sh`

------
https://chatgpt.com/codex/tasks/task_e_6846ad046d848320996ba4b57edca16e